### PR TITLE
Remove python2isms

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 1.0.0
 commit = False
 tag = False
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 
 machine:
   python:
-      version: 2.7.11
+      version: 3.6.2
 
 general:
   artifacts:
@@ -12,7 +12,7 @@ general:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.6.2  # Should correspond to pre-installed Python versions on CircleCI
+    - pyenv local 3.6.2
 
 test:
   override:

--- a/openapi/base.py
+++ b/openapi/base.py
@@ -6,12 +6,12 @@ these types inherit from the primitive types they extend, but add
 extra behavior to support type-conversion and schema validation.
 """
 from contextlib import closing
+from io import StringIO
 from json import dump, load
 from re import match
 from os.path import dirname, join
 
 from jsonschema import RefResolver, validate
-from six import StringIO
 
 from openapi.naming import make_key_name
 from openapi.registry import lookup, REGISTRY
@@ -40,7 +40,7 @@ class Schema(dict):
             raise
 
 
-class SchemaAware(object):
+class SchemaAware:
     """
     Schema-aware mix-in.
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "openapi"
-version = "0.6.0"
+version = "1.0.0"
 
 setup(
     name=project,
@@ -17,12 +17,11 @@ setup(
     keywords="openapi swagger",
     install_requires=[
         "inflection>=0.3.1",
-        "jsonschema>=2.5.1",
-        "six",
+        "jsonschema>=2.6.0",
     ],
     extras_require={
         "yaml": [
-            "PyYAML>=3.11",
+            "PyYAML>=3.12",
         ],
     },
     setup_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, lint
+envlist = py36, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
 - Build only 3.6
 - Remove six usage
 - Remove legacy class-object inheritance
 - Bump major version