### PR TITLE
Add format extra.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
-[bumpversion]
-current_version = 1.1.0
+[btumpversion]
+current_version = 1.1.1
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "openapi"
-version = "1.1.0"
+version = "1.1.1"
 
 setup(
     name=project,
@@ -20,7 +20,7 @@ setup(
     keywords="openapi swagger",
     install_requires=[
         "inflection>=0.3.1",
-        "jsonschema>=2.6.0",
+        "jsonschema[format]>=2.6.0",
     ],
     extras_require={
         "yaml": [


### PR DESCRIPTION
Why? The way we use openapi we usually use it with bravado. Both use jsonschema,
but `bravado` uses `jsonschema[format]`. As a result, if `openapi` is installed
first, when `bravado` is installed, it will see that `jsonschema` is installed
and fail to install the `format` extras. For simplicity sake, we just want to
add that extra here to avoid issues with the order that dependencies are
required.